### PR TITLE
Add -m flag to use MIN_DP instead of DP

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ N.B. This repository contains two functionally similar implementations of a cove
 extractor from gVCF files. The Python version is more readable and apt for modification, but the C version
 is roughly 12x faster.
 
-N.B. When a field that is specified using the `-f` flag is not present, the
-threshold will be applied to the `DP` field as a fall-back.
+N.B. When the `MIN_DP` field is not present (when using the `-m` flag), the `DP`
+field is used as a fall-back. This is typically the case for variants, since
+`MIN_DP` is not written for variant sites.
 
 ## Submitting to the Varda database
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ N.B. This repository contains two functionally similar implementations of a cove
 extractor from gVCF files. The Python version is more readable and apt for modification, but the C version
 is roughly 12x faster.
 
+N.B. When a field that is specified using the `-f` flag is not present, the
+threshold will be applied to the `DP` field as a fall-back.
 
 ## Submitting to the Varda database
 

--- a/gvcf2coverage/src/main.c
+++ b/gvcf2coverage/src/main.c
@@ -38,7 +38,7 @@ main(int argc, char* argv[])
     char* field = "DP";
 
     int opt = -1;
-    while ((opt = getopt(argc, argv, "t:nd:hf:")) != -1)
+    while ((opt = getopt(argc, argv, "t:nd:hm")) != -1)
     {
         switch (opt)
         {
@@ -59,8 +59,8 @@ main(int argc, char* argv[])
             case '?':
                 err = true;
                 break;
-            case 'f':
-                field = optarg;
+            case 'm':
+                field = "MIN_DP";
                 break;
         } // switch
     } // while
@@ -73,7 +73,7 @@ main(int argc, char* argv[])
 
     if (err || hflag)
     {
-        static char const* const usage = "usage: %s [-h] [-t threshold] [-d distance] [-n] [-f field]\n";
+        static char const* const usage = "usage: %s [-h] [-t threshold] [-d distance] [-n] [-m]\n";
         fprintf(stderr, usage, argv[0]);
         if (err)
         {


### PR DESCRIPTION
If the specified field can be found, the threshold will be applied to that
field. If the specified field cannot be found, the filter will be applied to
the DP field instead. This is most useful when filtering on MIN_DP, since
MIN_DP is not defined for variants, but DP is.