### PR TITLE
Prefer MIN_DP over DP

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ NB:
 ## Coverage
 
 This repository contains two functionally similar implementations of a coverage
-extractor from gVCF files.
+extractor from gVCF files.  Coverage is measuered in read depth. We use the
+`MIN_DP` field where available (non-variant regions) with a fallback to the
+`DP` field (variants).
 
 The Python version is more readable and apt for modification, but the C version
 is roughly 12x faster.

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,1 +1,5 @@
+*.gz
+*.varda
+
 gvcf2coverage
+

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,2 +1,16 @@
-gvcf2coverage: src/main.c
-	gcc -o $@ -Wall -Wextra -Wpedantic -std=c99 -O3 -I$(HTSLIB_INCDIR) -L$(HTSLIB_LIBDIR) src/main.c -lhts
+TARGET   = gvcf2coverage
+
+CC       = gcc
+CFLAGS   = -std=c99 -march=native -Wall -Wextra -Wpedantic \
+           -Wformat=2 -Wshadow -Wwrite-strings -Wstrict-prototypes \
+           -Wold-style-definition -Wredundant-decls -Wnested-externs \
+           -O3 -DNDEBUG
+
+
+$(TARGET): src/main.c
+	$(CC) -o $@ $(CFLAGS) -I$(HTSLIB_INCDIR) -L$(HTSLIB_LIBDIR) $< -lhts
+
+.PHONY: clean
+
+clean:
+	rm $(TARGET)

--- a/c/src/main.c
+++ b/c/src/main.c
@@ -117,9 +117,13 @@ main(int argc, char* argv[])
     while (0 == bcf_read(fh, hdr, rec))
     {
         int32_t depth = 0;
-        if (1 == bcf_get_format_int32(hdr, rec, "DP", &dp, &(int){0}))
+        if (1 == bcf_get_format_int32(hdr, rec, "MIN_DP", &dp, &(int){0}))
         {
             depth = dp[0];
+        } // if
+        else if (1 == bcf_get_format_int32(hdr, rec, "DP", &dp, &(int){0}))
+        {
+                depth = dp[0];
         } // if
 
         //

--- a/python/gvcf2coverage.py
+++ b/python/gvcf2coverage.py
@@ -27,10 +27,14 @@ def main(threshold, merge, distance):
         jump = False
 
         # Depth
-        dp = entry.format('DP')
+        dp = entry.format('MIN_DP')
 
         if dp is None:
-            depth = 0
+            dp = entry.format('DP')
+            if dp is None:
+                depth = 0
+            else
+                depth = dp[0][0]
         else:
             depth = dp[0][0]
 


### PR DESCRIPTION
This implements the changes suggested by @Redmar.
We prefer `MIN_DP` over `DP` for filtering.
I did not measure a run-time difference for the C code on a 700MB test sample.
The semantics are untested.